### PR TITLE
fix Markdown miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Echos.vim
+# Echos.vim
 More useful `:echomsg`.
 
 ```vim
-  :echom 'listA:' ['a', 'b', 'c']
-  "=> E730: using List as a String
+:echom 'listA:' ['a', 'b', 'c']
+"=> E730: using List as a String
 
-  :Echos 'listA:' ['a', 'b', 'c']
-  "=> listA: ['a', 'b', 'c']
+:Echos 'listA:' ['a', 'b', 'c']
+"=> listA: ['a', 'b', 'c']
 ```


### PR DESCRIPTION
ref https://gfx.hatenablog.com/entry/2017/08/14/174621

Markdown need space between heading sharp and title

```markdown
# heading
```

---

プラグインを利用させていただいているので、修正の手間を減らすくらいの役には立つかなと思いPRします。